### PR TITLE
Optimize AES-CTR: Loop unrolling and efficient counter handling

### DIFF
--- a/src/aesCtrCipher.h
+++ b/src/aesCtrCipher.h
@@ -39,7 +39,58 @@ public:
 
     void encrypt(uint8_t* src, size_t size, uint8_t* dst) const {
         __m128i counter = _mm_loadu_si128((const __m128i*)iv.data());
+        const __m128i mask = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+        const __m128i one_le = _mm_set_epi32(0, 0, 0, 1);
+        const __m128i two_le = _mm_set_epi32(0, 0, 0, 2);
+        const __m128i three_le = _mm_set_epi32(0, 0, 0, 3);
+        const __m128i four_le = _mm_set_epi32(0, 0, 0, 4);
+
+        // BE add constants (add to byte 15)
+        const __m128i one_be = _mm_set_epi8(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        const __m128i two_be = _mm_set_epi8(2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        const __m128i three_be = _mm_set_epi8(3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        const __m128i four_be = _mm_set_epi8(4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
         uint64_t i = 0;
+        int low_byte = iv[15];
+
+        for (; i + 64 <= size; i += 64) {
+            __m128i c0 = counter;
+            __m128i c1, c2, c3;
+
+            if (low_byte <= 251) {
+                // Optimized path: No shuffle needed, use byte addition
+                c1 = _mm_add_epi8(c0, one_be);
+                c2 = _mm_add_epi8(c0, two_be);
+                c3 = _mm_add_epi8(c0, three_be);
+
+                // Update counter for next iteration
+                counter = _mm_add_epi8(counter, four_be);
+            } else {
+                // Fallback path: Shuffle to LE, add, shuffle back
+                __m128i c_le = _mm_shuffle_epi8(c0, mask);
+
+                c1 = _mm_shuffle_epi8(_mm_add_epi64(c_le, one_le), mask);
+                c2 = _mm_shuffle_epi8(_mm_add_epi64(c_le, two_le), mask);
+                c3 = _mm_shuffle_epi8(_mm_add_epi64(c_le, three_le), mask);
+
+                // Update counter for next iteration
+                counter = _mm_shuffle_epi8(_mm_add_epi64(c_le, four_le), mask);
+            }
+            low_byte = (low_byte + 4) & 0xFF;
+
+            encryptBlock4(c0, c1, c2, c3);
+
+            __m128i b0 = _mm_loadu_si128((const __m128i*)(src + i));
+            __m128i b1 = _mm_loadu_si128((const __m128i*)(src + i + 16));
+            __m128i b2 = _mm_loadu_si128((const __m128i*)(src + i + 32));
+            __m128i b3 = _mm_loadu_si128((const __m128i*)(src + i + 48));
+
+            _mm_storeu_si128((__m128i*)(dst + i), _mm_xor_si128(b0, c0));
+            _mm_storeu_si128((__m128i*)(dst + i + 16), _mm_xor_si128(b1, c1));
+            _mm_storeu_si128((__m128i*)(dst + i + 32), _mm_xor_si128(b2, c2));
+            _mm_storeu_si128((__m128i*)(dst + i + 48), _mm_xor_si128(b3, c3));
+        }
 
         for (; i + 16 <= size; i += 16) {
             __m128i keyStream = encryptBlock(counter);
@@ -47,9 +98,8 @@ public:
             block = _mm_xor_si128(block, keyStream);
             _mm_storeu_si128((__m128i*)(dst + i), block);
 
-            const __m128i mask = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             counter = _mm_shuffle_epi8(counter, mask);
-            counter = _mm_add_epi64(counter, _mm_set_epi32(0, 0, 0, 1));
+            counter = _mm_add_epi64(counter, one_le);
             counter = _mm_shuffle_epi8(counter, mask);
         }
 
@@ -112,6 +162,30 @@ private:
         }
 
         return _mm_aesenclast_si128(counter, roundKeys[10]);
+    }
+
+    // Encrypts 4 blocks in parallel using interleaved AES instructions for better pipeline utilization.
+    // パイプライン利用効率を向上させるため、インターリーブされたAES命令を使用して4つのブロックを並列に暗号化します。
+    void encryptBlock4(__m128i& c0, __m128i& c1, __m128i& c2, __m128i& c3) const {
+        __m128i k = roundKeys[0];
+        c0 = _mm_xor_si128(c0, k);
+        c1 = _mm_xor_si128(c1, k);
+        c2 = _mm_xor_si128(c2, k);
+        c3 = _mm_xor_si128(c3, k);
+
+        for (int iRound = 1; iRound < 10; ++iRound) {
+            k = roundKeys[iRound];
+            c0 = _mm_aesenc_si128(c0, k);
+            c1 = _mm_aesenc_si128(c1, k);
+            c2 = _mm_aesenc_si128(c2, k);
+            c3 = _mm_aesenc_si128(c3, k);
+        }
+
+        k = roundKeys[10];
+        c0 = _mm_aesenclast_si128(c0, k);
+        c1 = _mm_aesenclast_si128(c1, k);
+        c2 = _mm_aesenclast_si128(c2, k);
+        c3 = _mm_aesenclast_si128(c3, k);
     }
 
     std::array<uint8_t, 16> key;


### PR DESCRIPTION
`AESCtrCipher::encrypt` was using about 20% of CPU. AI suggested to unroll the loop and interleave the aes instructions to improve CPU pipeline. AI coded the change with comments. I have verified on a file that generated output is binary identical to the previous code, and CPU usage in profiling for `encrypt` has reduced to 10.59% from 22.00%.

**タイトル**: AES-CTR暗号化の最適化：ループアンローリングとビッグエンディアンカウンタの効率化
**内容**:
1. `AESCtrCipher::encrypt` に4方向のループアンローリングを実装し、AES-NI命令のパイプライン処理を並列化しました。
2. カウンタのインクリメントロジックを最適化：98%のケースで冗長なシャッフル操作を回避し、SIMDバイト加算を使用してビッグエンディアンカウンタを直接更新する高速パスを導入しました。
3. 4つのブロックをインターリーブ処理するための `encryptBlock4` 関数を追加しました。

**Title**: Optimize AES-CTR performance: Loop unrolling and efficient Big-Endian counter handling
**Body**:
1. Implemented 4-way loop unrolling in `AESCtrCipher::encrypt` to parallelize AES-NI instructions.
2. Optimized Big-Endian counter increment logic: Introduced a fast path using SIMD byte addition to avoid redundant shuffle operations in 98% of cases.
3. Added `encryptBlock4` helper for interleaved processing of 4 blocks.