### PR TITLE
Optimize aribEncode: jisX0201KatakanaToKatakana

### DIFF
--- a/src/aribUtil.h
+++ b/src/aribUtil.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <string_view>
 
-const std::string aribEncode(const std::string& input, bool isCaption = false);
+const std::string aribEncode(std::string_view input, bool isCaption = false);
 const std::string aribEncode(const char* input, size_t size, bool isCaption = false);


### PR DESCRIPTION
`jisX0201KatakanaToKatakana` was using 6.59% of CPU doing string memory allocations. AI suggested to use a single string buffer to hold output. Also the loop lookup can be converted to a table lookup indexed by half-width katakana UTF-8 bytes. AI coded the change and I verified the result file. After refactoring, its CPU usage is reduced to 1.95%.

**タイトル**: パフォーマンス: `aribEncode` における文字列処理の最適化
**内容**:
1. `aribEncode` の主要な関数シグネチャを `std::string_view` を受け入れるように変更し、不要な文字列コピーとメモリ割り当てを排除しました。
2. `jisX0201KatakanaToKatakana` を O(N*M) のループ検索から O(N) のシングルパスにリファクタリングし、文字置換には O(1) のルックアップテーブルを使用しました。
3. `jisX0201KatakanaToKatakana` 内で `thread_local` バッファを使用し、変換中の繰り返しメモリ割り当てを回避しました。
4. `replaceSequence` の引数型を `std::string_view` に変更し、一時オブジェクトの生成を削減しました。

**Title**: Perf: Optimize string handling in `aribEncode`
**Body**:
1.  Changed the core `aribEncode` function signature to accept `std::string_view` to eliminate unnecessary string copies and memory allocations.
2.  Refactored `jisX0201KatakanaToKatakana` from an O(N*M) loop lookup to an O(N) single pass with an O(1) lookup table for character replacement.
3.  Used a `thread_local` buffer in `jisX0201KatakanaToKatakana` to avoid repeated memory allocations during conversion.
4.  Changed the parameter type of `replaceSequence` to `std::string_view` to reduce the creation of temporary objects.
