### PR TITLE
Optimize AES object by caching cipher object and keys

### DIFF
--- a/src/acasHandler.h
+++ b/src/acasHandler.h
@@ -6,6 +6,7 @@
 #include "acasCard.h"
 #include "smartCard.h"
 #include "casHandler.h"
+#include "aesCtrCipher.h"
 
 class AcasHandler : public MmtTlv::CasHandler {
 public:
@@ -32,4 +33,7 @@ private:
     std::thread workerThread;
     std::string acasServerUrl;
 
+    AESCtrCipher aes;
+    std::array<uint8_t, 16> lastKey{};
+    bool hasAESNI = false;
 };


### PR DESCRIPTION
Eliminate repeated expensive `hasAESNI` call.
Eliminate repeated `AESCtrCipher` instantiation and `expandKey` call.