### PR TITLE
Fix timezone-dependent EIT time conversion

### DIFF
--- a/src/remuxerHandler.cpp
+++ b/src/remuxerHandler.cpp
@@ -554,8 +554,10 @@ void RemuxerHandler::onMhEit(const MmtTlv::MhEit& mhEit) {
     tsid = mhEit.tlvStreamId;
 
     if (mhEit.isPf() && mhEit.sectionNumber == 0 && !mhEit.events.empty()) {
-        std::tm startTime = EITConvertStartTime((mhEit.events.begin())->get()->startTime);
-        programStartTime = static_cast<uint64_t>(std::mktime(&startTime));
+        uint64_t startTime{};
+        if (EITConvertStartTimeToUnixTime((mhEit.events.begin())->get()->startTime, &startTime)) {
+            programStartTime = startTime;
+        }
     }
 
     ts::EIT tsEit(true, mhEit.isPf(), 0, mhEit.versionNumber, true, mhEit.serviceId, mhEit.tlvStreamId, mhEit.originalNetworkId);

--- a/src/timeUtil.cpp
+++ b/src/timeUtil.cpp
@@ -1,4 +1,5 @@
 #include "timeUtil.h"
+#include <chrono>
 #include <cstdint>
 #include <ctime>
 
@@ -44,6 +45,38 @@ struct tm EITConvertStartTime(uint64_t i_date) {
     tm.tm_isdst = 0;
 
     return tm;
+}
+
+bool EITConvertStartTimeToUnixTime(uint64_t i_date, uint64_t* p_unix_time) {
+    if (i_date == UNKNOWN_START_TIME || p_unix_time == nullptr) {
+        return false;
+    }
+
+    const struct tm startTime = EITConvertStartTime(i_date);
+    const std::chrono::year_month_day date{
+        std::chrono::year{startTime.tm_year + BASE_YEAR},
+        std::chrono::month{static_cast<unsigned>(startTime.tm_mon + 1)},
+        std::chrono::day{static_cast<unsigned>(startTime.tm_mday)}
+    };
+    if (!date.ok() || startTime.tm_hour < 0 || startTime.tm_hour > 23 ||
+        startTime.tm_min < 0 || startTime.tm_min > 59 ||
+        startTime.tm_sec < 0 || startTime.tm_sec > 59) {
+        return false;
+    }
+
+    constexpr std::chrono::hours JST_OFFSET{9};
+    const auto utcTime = std::chrono::sys_days{date} +
+        std::chrono::hours{startTime.tm_hour} +
+        std::chrono::minutes{startTime.tm_min} +
+        std::chrono::seconds{startTime.tm_sec} - JST_OFFSET;
+    const auto unixTime = std::chrono::duration_cast<std::chrono::seconds>(
+        utcTime.time_since_epoch()).count();
+    if (unixTime < 0) {
+        return false;
+    }
+
+    *p_unix_time = static_cast<uint64_t>(unixTime);
+    return true;
 }
 
 int EITConvertDuration(uint32_t i_duration) {

--- a/src/timeUtil.h
+++ b/src/timeUtil.h
@@ -4,4 +4,5 @@
 
 void EITDecodeMjd(int i_mjd, int* p_y, int* p_m, int* p_d);
 struct tm EITConvertStartTime(uint64_t i_date);
+bool EITConvertStartTimeToUnixTime(uint64_t i_date, uint64_t* p_unix_time);
 int EITConvertDuration(uint32_t i_duration);


### PR DESCRIPTION
This PR fixes an issue where EIT program times were converted using the host machine's local timezone.

EIT date and time values are expressed in JST (UTC+9), but `std::mktime()` interprets them as local time. As a result, the generated Unix timestamps differed depending on the timezone configured on the machine running the application.